### PR TITLE
Use env var to configure docker client

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,11 +13,7 @@ func main() {
 	c := cli.NewCLI("gourmet", "0.0.0")
     c.Args = os.Args[1:]
 
-	client, _ := docker.NewTLSClient(
-		"http://192.168.99.100:2376",
-		"/Users/garbezzano/.docker/machine/machines/default/cert.pem",
-		"/Users/garbezzano/.docker/machine/machines/default/key.pem",
-		"/Users/garbezzano/.docker/machine/machines/default/ca.pem")
+	client, _ := docker.NewClientFromEnv()
 
 	dockerRunner := dockerRun.DockerRunner{client, stream.ConsoleStream{}}
 


### PR DESCRIPTION
Fixed #6

Client instance ready for communication created from Docker's default
logic for the environment variables DOCKER_HOST, DOCKER_TLS_VERIFY, and
DOCKER_CERT_PATH.
see https://godoc.org/github.com/fsouza/go-dockerclient#NewClientFromEnv
