### PR TITLE
Start to use context to print output

### DIFF
--- a/runner/stream/buffer.go
+++ b/runner/stream/buffer.go
@@ -12,6 +12,6 @@ func (r BufferStream) Write(data []byte) (n int, err error) {
 	return r.Buffer.Write(data)
 }
 
-func (r BufferStream) String() (string) {
+func (r BufferStream) String() string {
 	return r.Buffer.String()
 }


### PR DESCRIPTION
`Context` is the way that we have to communicate an output from a function.
At the moment the idea is manage that like stdOut from a container.

Your function print on stdOut a Json formatted like 

``` json
{
    "StatusCode": 200,
    "Headers": {
        "Content-Type": "application/json",
        "X-From-Func": "send-email"
    },
    "Body": {"emailI": 12512523}
}
```

This string will be mapped to build the HTTP response
